### PR TITLE
Add foreman setup role

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -23,3 +23,4 @@
     - foreman
     - foreman_apache
     - foreman_proxy
+    - foreman_setup

--- a/roles/foreman_setup/tasks/main.yml
+++ b/roles/foreman_setup/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: 'Registration playbook'
+  copy:
+    src: templates/register.yaml
+    dest: /etc/foreman/register.yaml
+    owner: root
+    group: root
+    mode: 0600
+
+- name: Add localhost as unmanaged host
+  command: "ansible-playbook /etc/foreman/register.yaml -e foreman_admin_password={{ foreman_admin_password }}"

--- a/roles/foreman_setup/templates/register.yaml
+++ b/roles/foreman_setup/templates/register.yaml
@@ -1,0 +1,35 @@
+---
+- hosts: localhost
+  vars:
+    url: "https://{{ ansible_fqdn }}/api/v2/hosts"
+    data:
+      host:
+        name: "{{ ansible_fqdn }}"
+        location_id: 2
+        organization_id: 1
+        ip: "{{ ansible_default_ipv4.address }}"
+        build: false
+        managed: false
+  tasks:
+    - name: "register unmanaged host"
+      uri:
+        force_basic_auth: yes
+        headers:
+          Content-Type: "application/json"
+        method: POST
+        return_content: yes
+        timeout: 3
+        user: admin
+        password: "{{ foreman_admin_password }}"
+        validate_certs: false
+        url: "{{ url }}"
+        body: "{{ data | to_json }}"
+      register: registration_result
+      until: (registration_result.json is defined) and (registration_result.status == 422 or registration_result.status == 200)
+      retries: 300
+      delay: 4
+      ignore_errors: true
+
+    - fail:
+        msg: "{{ registration_result }}"
+      when: registration_result.status != 422 and registration_result.status != 200


### PR DESCRIPTION
This role aims to do necessary setup in order to make Foreman self
configurable. It's a separate role since need to make sure the installation
has finished and is fully functional. This role is not yet related
to foreman_setup plugin or any of its successor but once that's available
it should probably configure it too.